### PR TITLE
Adiciona suporte a nova forma de criar boletos

### DIFF
--- a/src/Api/Boleto.php
+++ b/src/Api/Boleto.php
@@ -274,9 +274,9 @@ class Boleto implements ParserInteface
     }
 
     /**
-     * @return string
+     * @return array
      */
-    public function getInstrucao(): string
+    public function getInstrucao(): array
     {
         return $this->instrucao;
     }
@@ -356,6 +356,7 @@ class Boleto implements ParserInteface
      */
     public function parser(): array
     {
+    	$beneficiario = (!empty($this->getBeneficiario())) ? $this->getBeneficiario()->parser() : [];
         return array_merge_recursive([
             'boleto.emissao'    => $this->emissao->format('Y-m-d'),
             'boleto.vencimento' => $this->vencimento->format('Y-m-d'),
@@ -363,6 +364,6 @@ class Boleto implements ParserInteface
             'boleto.numero'     => $this->numero,
             'boleto.titulo'     => $this->titulo,
             'boleto.valor'      => $this->valor,
-        ], $this->getConta()->parser(), $this->getBeneficiario()->parser(), $this->getPagador()->parser());
+        ], $this->getConta()->parser(), $beneficiario, $this->getPagador()->parser());
     }
 }

--- a/src/Api/Boleto.php
+++ b/src/Api/Boleto.php
@@ -64,7 +64,7 @@ class Boleto implements ParserInteface
     private $multa;
 
     /**
-     * @var array
+     * @var string
      */
     private $instrucao;
 
@@ -274,9 +274,9 @@ class Boleto implements ParserInteface
     }
 
     /**
-     * @return array
+     * @return string
      */
-    public function getInstrucao(): array
+    public function getInstrucao(): string
     {
         return $this->instrucao;
     }
@@ -314,9 +314,9 @@ class Boleto implements ParserInteface
     }
 
     /**
-     * @return Beneficiario
+     * @return Beneficiario|null
      */
-    public function getBeneficiario(): Beneficiario
+    public function getBeneficiario(): ?Beneficiario
     {
         return $this->beneficiario;
     }
@@ -356,7 +356,7 @@ class Boleto implements ParserInteface
      */
     public function parser(): array
     {
-    	$beneficiario = (!empty($this->getBeneficiario())) ? $this->getBeneficiario()->parser() : [];
+    	$beneficiario = (!empty($this->beneficiario)) ? $this->getBeneficiario()->parser() : [];
         return array_merge_recursive([
             'boleto.emissao'    => $this->emissao->format('Y-m-d'),
             'boleto.vencimento' => $this->vencimento->format('Y-m-d'),

--- a/src/Api/Boleto/Beneficiario.php
+++ b/src/Api/Boleto/Beneficiario.php
@@ -61,14 +61,6 @@ class Beneficiario implements ParserInteface
         return $this;
     }
 
-    public function parser(): array
-    {
-        return array_merge([
-            'boleto.beneficiario.nome' => $this->nome,
-            'boleto.beneficiario.cprf' => $this->cprf,
-        ], $this->getEndereco()->parser());
-    }
-
     /**
      * @return Endereco
      */
@@ -87,4 +79,12 @@ class Beneficiario implements ParserInteface
 
         return $this;
     }
+
+	public function parser(): array
+	{
+		return array_merge([
+			'boleto.beneficiario.nome' => $this->nome,
+			'boleto.beneficiario.cprf' => $this->cprf,
+		], $this->getEndereco()->parser());
+	}
 }

--- a/src/Api/Boleto/Conta.php
+++ b/src/Api/Boleto/Conta.php
@@ -28,6 +28,11 @@ class Conta implements ParserInteface
      */
     private $carteira;
 
+	/**
+	 * @var string
+	 */
+	private $token;
+
     /**
      * @return string
      */
@@ -104,13 +109,34 @@ class Conta implements ParserInteface
         return $this;
     }
 
+	/**
+	 * @return string
+	 */
+	public function getToken(): string
+	{
+		return $this->token;
+	}
+
+	/**
+	 * @param string $token
+	 * @return Conta
+	 */
+	public function setToken(string $token): Conta
+	{
+		$this->token = $token;
+
+		return $this;
+	}
+
     public function parser(): array
     {
-        return [
-            'boleto.conta.banco'    => $this->banco,
-            'boleto.conta.agencia'  => $this->agencia,
-            'boleto.conta.numero'   => $this->numero,
-            'boleto.conta.carteira' => $this->carteira,
-        ];
+        return ($this->token != null) ?
+	        ['boleto.token.token' => $this->token] :
+	        [
+	            'boleto.conta.banco'    => $this->banco,
+	            'boleto.conta.agencia'  => $this->agencia,
+	            'boleto.conta.numero'   => $this->numero,
+	            'boleto.conta.carteira' => $this->carteira,
+	        ];
     }
 }

--- a/src/Api/Boleto/Conta.php
+++ b/src/Api/Boleto/Conta.php
@@ -131,7 +131,7 @@ class Conta implements ParserInteface
     public function parser(): array
     {
         return ($this->token != null) ?
-	        ['boleto.token.token' => $this->token] :
+	        ['boleto.conta.token' => $this->token] :
 	        [
 	            'boleto.conta.banco'    => $this->banco,
 	            'boleto.conta.agencia'  => $this->agencia,

--- a/src/Api/Client.php
+++ b/src/Api/Client.php
@@ -36,10 +36,11 @@ class Client
      */
     private $baseUrl;
 
-    /**
-     * Boleto constructor.
-     * @param array $params
-     */
+	/**
+	 * Boleto constructor.
+	 * @param array $params
+	 * @throws \Exception
+	 */
     public function __construct(array $params = [])
     {
         if (!empty($params['env'])) {

--- a/tests/Tests/BoletoCloud/BoletoTest.php
+++ b/tests/Tests/BoletoCloud/BoletoTest.php
@@ -12,7 +12,7 @@ use BoletoCloud\Api\Client;
  * Class BoletoTest
  * @package Tests\BoletoCloud
  */
-class BoletoTest extends \PHPUnit_Framework_TestCase
+class BoletoTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var Client
@@ -68,9 +68,9 @@ class BoletoTest extends \PHPUnit_Framework_TestCase
             ->setBeneficiario($beneficiario)
             ->setPagador($pagador)
             ->setEmissao(new \DateTime('2017-01-31'))
-            ->setVencimento(new \DateTime('2017-02-05'))
+            ->setVencimento(new \DateTime())
             ->setDocumento('EX1')
-            ->setNumero(rand(10000000000, 99999999999) . '-P')
+            ->setNumero(rand(11111, 99999).rand(111111, 999999).'-P')
             ->setTitulo('DM')
             ->setValor(121.53)
             ->setInstrucao([
@@ -80,6 +80,7 @@ class BoletoTest extends \PHPUnit_Framework_TestCase
             ]);
 
         $retorno = $this->client->gerarBoleto($boleto);
+        $this->assertArrayHasKey('boleto_url', $retorno);
         $this->assertEquals(201, $retorno['request']->getStatusCode());
     }
 
@@ -126,7 +127,7 @@ class BoletoTest extends \PHPUnit_Framework_TestCase
             ->setEmissao(new \DateTime('2017-01-31'))
             ->setVencimento(new \DateTime('2017-02-05'))
             ->setDocumento('EX1')
-            ->setNumero(rand(10000000000, 99999999999) . '-P')
+            ->setNumero(rand(10000000, 99999999) . '-P')
             ->setTitulo('DM')
             ->setValor(121.53)
             ->setInstrucao([
@@ -138,42 +139,4 @@ class BoletoTest extends \PHPUnit_Framework_TestCase
         $retorno = $this->client->gerarBoleto($boleto);
         $this->assertObjectHasAttribute('erro', $retorno);
     }
-
-	public function testCriarBoletoNovaFormaAcerto()
-	{
-		$conta = new Conta();
-		$conta->setToken("api-keyEXEMLODETOKEN");
-
-		$pagadorEndereco = new Boleto\Endereco("pagador");
-		$pagadorEndereco->setCep("36240-000")
-			->setLogradouro("BR-499")
-			->setNumero("s/n")
-			->setBairro("Casa Natal")
-			->setLocalidade("Santos Dumont")
-			->setUf("MG")
-			->setComplemento("Sítio - Subindo a serra da Mantiqueira");
-
-		$pagador = new Pagador();
-		$pagador->setNome("Alberto Santos Dumont")
-			->setCprf("111.111.111-11")
-			->setEndereco($pagadorEndereco);
-
-		$boleto = new Boleto();
-		$boleto->setConta($conta)
-			->setPagador($pagador)
-			->setEmissao(new \DateTime('2017-01-31'))
-			->setVencimento(new \DateTime('2017-02-05'))
-			->setDocumento('EX1')
-			->setNumero(rand(10000000000, 99999999999) . '-P')
-			->setTitulo('DM')
-			->setValor(121.53)
-			->setInstrucao([
-				'Atenção! NÃO RECEBER ESTE BOLETO.' . date('d-m-y H:i:s'),
-				'Este é apenas um teste utilizando a API Boleto Cloud' . date('d-m-y H:i:s'),
-				'Mais info em http://www.boletocloud.com/app/dev/api' . date('d-m-y H:i:s'),
-			]);
-
-		$retorno = $this->client->gerarBoleto($boleto);
-		$this->assertEquals(201, $retorno['request']->getStatusCode());
-	}
 }

--- a/tests/Tests/BoletoCloud/BoletoTest.php
+++ b/tests/Tests/BoletoCloud/BoletoTest.php
@@ -138,4 +138,42 @@ class BoletoTest extends \PHPUnit_Framework_TestCase
         $retorno = $this->client->gerarBoleto($boleto);
         $this->assertObjectHasAttribute('erro', $retorno);
     }
+
+	public function testCriarBoletoNovaFormaAcerto()
+	{
+		$conta = new Conta();
+		$conta->setToken("api-keyEXEMLODETOKEN");
+
+		$pagadorEndereco = new Boleto\Endereco("pagador");
+		$pagadorEndereco->setCep("36240-000")
+			->setLogradouro("BR-499")
+			->setNumero("s/n")
+			->setBairro("Casa Natal")
+			->setLocalidade("Santos Dumont")
+			->setUf("MG")
+			->setComplemento("Sítio - Subindo a serra da Mantiqueira");
+
+		$pagador = new Pagador();
+		$pagador->setNome("Alberto Santos Dumont")
+			->setCprf("111.111.111-11")
+			->setEndereco($pagadorEndereco);
+
+		$boleto = new Boleto();
+		$boleto->setConta($conta)
+			->setPagador($pagador)
+			->setEmissao(new \DateTime('2017-01-31'))
+			->setVencimento(new \DateTime('2017-02-05'))
+			->setDocumento('EX1')
+			->setNumero(rand(10000000000, 99999999999) . '-P')
+			->setTitulo('DM')
+			->setValor(121.53)
+			->setInstrucao([
+				'Atenção! NÃO RECEBER ESTE BOLETO.' . date('d-m-y H:i:s'),
+				'Este é apenas um teste utilizando a API Boleto Cloud' . date('d-m-y H:i:s'),
+				'Mais info em http://www.boletocloud.com/app/dev/api' . date('d-m-y H:i:s'),
+			]);
+
+		$retorno = $this->client->gerarBoleto($boleto);
+		$this->assertEquals(201, $retorno['request']->getStatusCode());
+	}
 }


### PR DESCRIPTION
Na nova forma, deve-se apenas enviar um token relativo à uma conta bancária previamente cadastrada. Assim, nenhum outro campo de `conta` ou `beneficiario` deve ser enviado.
Corrige também os unit tests.